### PR TITLE
Fix Prisma client not being copied to dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && mkdir -p dist/generated && cp -r src/generated/prisma dist/generated/",
+    "postinstall": "prisma generate",
     "dev": "node --no-warnings --loader ts-node/esm src/index.ts",
     "start": "node dist/index.js",
     "test": "echo \"No tests specified\" && exit 0"


### PR DESCRIPTION
## Summary
- Added build step to copy Prisma client files to dist directory
- Added postinstall script to automatically generate Prisma client
- Fixes production error: ERR_MODULE_NOT_FOUND for prisma/index.js

## Test plan
- Verify build process creates all necessary files in dist directory
- Check that Prisma client is available in production environment

🤖 Generated with [Claude Code](https://claude.ai/code)